### PR TITLE
opmon preview CLI command

### DIFF
--- a/opmon/config.py
+++ b/opmon/config.py
@@ -112,4 +112,6 @@ def validate(
     else:
         raise Exception(f"Unable to validate config: {config}")
 
-    Monitoring("no project", "no dataset", config.slug, resolved_config).validate()
+    Monitoring(
+        "no project", "no dataset", "no derived dataset", config.slug, resolved_config
+    ).validate()

--- a/opmon/metadata.py
+++ b/opmon/metadata.py
@@ -23,6 +23,7 @@ class Metadata:
 
     project: str
     dataset: str
+    derived_dataset: str
     projects: List[Tuple[str, MonitoringConfiguration]]
 
     @property
@@ -40,7 +41,7 @@ class Metadata:
 
     def write(self) -> None:
         """Update the BQ table with project metadata."""
-        destination_table = f"{self.project}.{self.dataset}_derived.{PROJECTS_TABLE}"
+        destination_table = f"{self.project}.{self.derived_dataset}.{PROJECTS_TABLE}"
 
         # check if projects metadata table exists; otherwise it needs to be created
         first_run = True
@@ -92,6 +93,7 @@ class Metadata:
         render_kwargs = {
             "gcp_project": self.project,
             "dataset": self.dataset,
+            "derived_dataset": self.derived_dataset,
             "table": PROJECTS_TABLE,
             "projects": project_metadata,
             "first_run": first_run,
@@ -104,7 +106,7 @@ class Metadata:
         view_query = f"""
             CREATE OR REPLACE VIEW `{self.project}.{self.dataset}.{view_name}` AS (
                 SELECT *
-                FROM `{self.project}.{self.dataset}_derived.{PROJECTS_TABLE}`
+                FROM `{self.project}.{self.derived_dataset}.{PROJECTS_TABLE}`
             )
         """
 

--- a/opmon/templates/alerts_view.sql
+++ b/opmon/templates/alerts_view.sql
@@ -6,4 +6,4 @@ AS
 SELECT 
     *
 FROM
-    `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_alerts_v{{ table_version }}`
+    `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_alerts_v{{ table_version }}`

--- a/opmon/templates/metric_view.sql
+++ b/opmon/templates/metric_view.sql
@@ -7,18 +7,18 @@ AS
 SELECT 
     *
 FROM
-    `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_v{{ table_version }}`
+    `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_v{{ table_version }}`
 {% else %}
 WITH most_recent_date AS (
     SELECT 
         MAX(submission_date) AS most_recent
     FROM
-        `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_v{{ table_version }}`
+        `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_v{{ table_version }}`
 )
 SELECT
     *
 FROM 
-    `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_v{{ table_version }}`,
+    `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_v{{ table_version }}`,
     most_recent_date
 WHERE
     PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) = DATE_ADD(submission_date, INTERVAL 14 DAY) OR

--- a/opmon/templates/projects.sql
+++ b/opmon/templates/projects.sql
@@ -1,5 +1,5 @@
 {% if first_run -%}
-CREATE TABLE `{{ gcp_project }}.{{ dataset }}_derived.{{ table }}` (
+CREATE TABLE `{{ gcp_project }}.{{ derived_dataset }}.{{ table }}` (
     slug STRING,
     name STRING,
     xaxis STRING,
@@ -16,7 +16,7 @@ CREATE TABLE `{{ gcp_project }}.{{ dataset }}_derived.{{ table }}` (
 
 BEGIN TRANSACTION;
 
-DELETE FROM `{{ gcp_project }}.{{ dataset }}_derived.{{ table }}`
+DELETE FROM `{{ gcp_project }}.{{ derived_dataset }}.{{ table }}`
 WHERE 
 {% for project in projects %}
 slug = "{{ project.slug }}"
@@ -24,7 +24,7 @@ slug = "{{ project.slug }}"
 {% endfor %}
 ;
 
-INSERT `{{ gcp_project }}.{{ dataset }}_derived.{{ table }}` 
+INSERT `{{ gcp_project }}.{{ derived_dataset }}.{{ table }}` 
 (slug, name, xaxis, branches, dimensions, summaries, start_date, end_date, group_by_dimension, alerting, compact_visualization)
 VALUES 
 {% for project in projects %}

--- a/opmon/templates/statistics_query.sql
+++ b/opmon/templates/statistics_query.sql
@@ -58,7 +58,7 @@ buckets_by_metric AS (
 --     SELECT
 --         * 
 --     FROM
---         `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}`
+--         `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}`
 --     {% if dimensions | length > 0 %}
 --     WHERE
 --     {% for dimension in dimensions -%}
@@ -80,7 +80,7 @@ buckets_by_metric AS (
 --             {% endfor %}
 --         )
 --     FROM
---         `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}` AS o
+--         `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}` AS o
 --     WHERE
 --         TRUE
 --         {% for is_all in perm %}
@@ -104,7 +104,7 @@ SELECT
         {{ "," if not loop.last else "" }}
     {% endfor %}
 FROM
-    `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_v{{ table_version }}` 
+    `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_v{{ table_version }}` 
 CROSS JOIN buckets_by_metric
 WHERE submission_date = DATE("{{ submission_date }}")
 GROUP BY

--- a/opmon/templates/statistics_view.sql
+++ b/opmon/templates/statistics_view.sql
@@ -9,20 +9,20 @@ WITH stats AS (
     SELECT 
         * 
     FROM
-    `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_statistics_v{{ table_version }}`
+    `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_statistics_v{{ table_version }}`
 )
 {% else %}
 WITH most_recent_date AS (
     SELECT 
         MAX(submission_date) AS most_recent
     FROM
-        `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_statistics_v{{ table_version }}`
+        `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_statistics_v{{ table_version }}`
 ),
 stats AS (
     SELECT
         *
     FROM 
-        `{{ gcp_project }}.{{ dataset }}_derived.{{ normalized_slug }}_statistics_v{{ table_version }}`,
+        `{{ gcp_project }}.{{ derived_dataset }}.{{ normalized_slug }}_statistics_v{{ table_version }}`,
         most_recent_date
     WHERE
         PARSE_DATE('%Y%m%d', CAST(build_id AS STRING)) = DATE_SUB(submission_date, INTERVAL 14 DAY) OR

--- a/opmon/tests/test_monitoring.py
+++ b/opmon/tests/test_monitoring.py
@@ -14,7 +14,13 @@ from opmon.monitoring import Monitoring
 class TestMonitoring:
     def test_init_monitoring(self):
         conf = MonitoringConfiguration()
-        monitoring = Monitoring(project="test", dataset="test", slug="test-foo", config=conf)
+        monitoring = Monitoring(
+            project="test",
+            dataset="test",
+            derived_dataset="test_derived",
+            slug="test-foo",
+            config=conf,
+        )
         assert monitoring.normalized_slug == "test_foo"
 
     def test_check_runnable(self):
@@ -40,6 +46,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )
@@ -71,6 +78,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )
@@ -102,6 +110,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )
@@ -121,6 +130,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )
@@ -158,6 +168,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )
@@ -198,6 +209,7 @@ class TestMonitoring:
         monitoring = Monitoring(
             project="test",
             dataset="test",
+            derived_dataset="test_derived",
             slug="test-foo",
             config=spec.resolve(experiment=None, configs=ConfigLoader.configs),
         )


### PR DESCRIPTION
This PR adds a new `bqetl preview` command which will write a subset of data for a specific config to a temporary location. The data can be visualized via https://github.com/mozilla/looker-spoke-default/pull/457

Generating the preview would look like: 

```
> gcloud auth login --update-adc 
> opmon preview --slug=firefox-install-demo  --config_file='path/to/firefox-install-demo.toml'

A preview is available at: https://mozilla.cloud.looker.com/dashboards/975?Table="mozdata.tmp.firefox_install_demo"&Submission+Date=2022-11-18+to+2022-11-21
Start running backfill for firefox-install-demo: [...]
```

cc @ncalexan

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-544)
