### PR TITLE
Remove pytest-flake8

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ exceptiongroup==1.1.0
     #   cattrs
     #   pytest
 flake8==6.0.0
-    # via pytest-flake8
+    # via mozilla-opmon
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.30
@@ -139,13 +139,10 @@ pytest==7.2.1
     #   mozilla-opmon
     #   pytest-black
     #   pytest-cov
-    #   pytest-flake8
     #   pytest-pydocstyle
 pytest-black==0.3.12
     # via mozilla-opmon
 pytest-cov==4.0.0
-    # via mozilla-opmon
-pytest-flake8==1.1.1
     # via mozilla-opmon
 pytest-pydocstyle==2.3.2
     # via mozilla-opmon

--- a/requirements.txt
+++ b/requirements.txt
@@ -211,9 +211,7 @@ exceptiongroup==1.1.0 \
 flake8==6.0.0 \
     --hash=sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7 \
     --hash=sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181
-    # via
-    #   -r requirements.in
-    #   pytest-flake8
+    # via -r requirements.in
 gitdb==4.0.10 \
     --hash=sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a \
     --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
@@ -655,7 +653,6 @@ pytest==7.2.1 \
     #   -r requirements.in
     #   pytest-black
     #   pytest-cov
-    #   pytest-flake8
     #   pytest-pydocstyle
 pytest-black==0.3.12 \
     --hash=sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5
@@ -663,10 +660,6 @@ pytest-black==0.3.12 \
 pytest-cov==4.0.0 \
     --hash=sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b \
     --hash=sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470
-    # via -r requirements.in
-pytest-flake8==1.1.1 \
-    --hash=sha256:ba4f243de3cb4c2486ed9e70752c80dd4b636f7ccb27d4eba763c35ed0cd316e \
-    --hash=sha256:e0661a786f8cbf976c185f706fdaf5d6df0b1667c3bcff8e823ba263618627e7
     # via -r requirements.in
 pytest-pydocstyle==2.3.2 \
     --hash=sha256:a30b28d49607b2fcd7b24678ab6c4e27a288710a34b3a0f1f90f3497e88771c3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ test_dependencies = [
     "pytest-black",
     "pytest-cov",
     "pytest-pydocstyle",
-    "pytest-flake8",
+    "flake8",
     "mypy",
     "types-futures",
     "types-pkg-resources",


### PR DESCRIPTION
it hasn't been updated to work with flake8>=5 and this project uses flake8 6

fixes #127

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-715)
