### PR TITLE
Add submission_timestamp column sibling to submission_date. (#126)

### DIFF
--- a/opmon/templates/statistics_view.sql
+++ b/opmon/templates/statistics_view.sql
@@ -34,6 +34,7 @@ stats AS (
 {% for summary in summaries %}
     SELECT 
         submission_date,
+        TIMESTAMP(submission_date) AS submission_timestamp,
         build_id,
         {% for dimension in dimensions -%}
             {{ dimension.name }},


### PR DESCRIPTION
This makes it easier to visualize Opmon aggregate metrics in Grafana: Grafana's Bigquery integration is fundamentally `TIMESTAMP` shaped, not `DATE` shaped, and this avoids writing nested queries.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-738)
