### PR TITLE
Handle client_id_columns set to NULL

### DIFF
--- a/opmon/templates/metric_query.sql
+++ b/opmon/templates/metric_query.sql
@@ -31,7 +31,9 @@ merged_metrics_{{ data_source }} AS (
         ) AS p
     ON
         {{ metrics[0].data_source.submission_date_column }} = p.population_submission_date
+        {% if metrics[0].data_source.client_id_column != "NULL" %}
         AND {{ metrics[0].data_source.client_id_column }} = p.population_client_id
+        {% endif %}
         {% if config.xaxis.value == "submission_date" %}
         AND p.population_build_id IS NULL
         {% else %}
@@ -71,7 +73,9 @@ joined_metrics AS (
   LEFT JOIN merged_metrics_{{ data_source }}
   ON
     merged_metrics_{{ data_source }}.submission_date = population.submission_date AND
+    {% if metrics[0].data_source.client_id_column != "NULL" %}
     merged_metrics_{{ data_source }}.client_id = population.client_id AND
+    {% endif %}
     (population.build_id IS NULL OR merged_metrics_{{ data_source }}.build_id = population.build_id)
   {% endfor %}
 ),

--- a/opmon/templates/population.sql
+++ b/opmon/templates/population.sql
@@ -55,6 +55,9 @@ WITH population AS (
             SELECT {{ config.population.data_source.client_id_column }} AS client_id
             FROM {{ config.population.data_source.from_expr_for(app_id) }} 
             WHERE {{ config.population.data_source.submission_date_column }} = DATE('{{ submission_date }}')
+            -- client_id is set to NULL when we want to compute metrics across all clients (default is per client)
+            -- keep 'NULL' clients
+            AND {{ config.population.data_source.client_id_column }} IS NOT NULL
             GROUP BY client_id
             HAVING COUNT(*) > 10000
           )


### PR DESCRIPTION
See https://github.com/mozilla/metric-hub/pull/275

We should handle `client_id_column = "NULL"` in OpMon

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2073)
