### PR TITLE
add VPN

### DIFF
--- a/platform_config.toml
+++ b/platform_config.toml
@@ -37,6 +37,14 @@ app_id = { release = "org.mozilla.focus", beta = "org.mozilla.focus.beta", night
 is_glean_app = true
 app_id = { release = "monitor.cirrus" }
 
-[platform.vpn]
+[platform.mozilla_vpn]
 is_glean_app = true
-app_id = { desktop = "mozillavpn", ios = "org_mozilla_ios_firefoxvpn", android = "org_mozilla_firefox_vpn"}
+app_id = { release = "mozillavpn" }
+
+[platform.mozilla_vpn_ios]
+is_glean_app = true
+app_id = { release = "org.mozilla.ios.FirefoxVPN" }
+
+[platform.mozilla_vpn_android]
+is_glean_app = true
+app_id = { release = "org.mozilla.firefox.vpn" }

--- a/platform_config.toml
+++ b/platform_config.toml
@@ -36,3 +36,7 @@ app_id = { release = "org.mozilla.focus", beta = "org.mozilla.focus.beta", night
 [platform.monitor_cirrus]
 is_glean_app = true
 app_id = { release = "monitor.cirrus" }
+
+[platform.vpn]
+is_glean_app = true
+app_id = { desktop = "mozillavpn", ios = "org_mozilla_ios_firefoxvpn", android = "org_mozilla_firefox_vpn"}


### PR DESCRIPTION
I need the VPN datasets to do OpMon stuff with it :)

not sure if I used the app_id thing correct ... but we have VPN coming from android, ios or desktop

there is a combined dataset in mozdata, but it is somewhat confusing since part of it has main ping but other parts have baseline ping .. so it feels saver look at them seperately?

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/DENG-2122)
