### PR TITLE
Fix 178 move comma in metric query

### DIFF
--- a/mozilla_vpn.toml
+++ b/mozilla_vpn.toml
@@ -1,0 +1,142 @@
+
+[project]
+
+name = "Mozilla VPN"
+platform = "fenix" # not really but needs some platform. I'm overwriting everything
+xaxis = "submission_date"
+start_date = "2023-12-02"
+skip = false
+is_rollout = false
+skip_default_metrics = true
+compact_visualization = false
+metrics = [
+    "session_count",
+    "avg_session_duration",
+    "active_subscribers",
+    "avg_sum_session_duration",
+    # "cnt_session_starts",
+    # "cnt_session_ends",
+    # "cnt_sessions_start_and_end",
+]
+
+[project.population]
+
+data_source = "base_table"
+monitor_entire_population = true
+dimensions = ["app"]
+group_by_dimension = "app"
+
+
+[data_sources]
+[data_sources.base_table]
+from_expression = """
+    (
+        SELECT
+            "vpnsession" as source_table,
+            DATE(v.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - vpn") as app,
+            CASE v.normalized_app_id
+                WHEN "mozillavpn" THEN v.client_info.client_id
+                ELSE v.metrics.uuid.session_installation_id
+            END AS client_id,
+            v.metrics.uuid.session_session_id AS session_id,
+            v.metrics.datetime.session_session_start AS session_start,
+            v.metrics.datetime.session_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` AS v
+
+        UNION ALL
+        SELECT 
+            "daemonsession" AS source_table,
+            DATE(d.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - daemon") AS app,
+            d.metrics.uuid.session_installation_id AS client_id,
+            d.metrics.uuid.session_daemon_session_id AS session_id,
+            d.metrics.datetime.session_daemon_session_start AS session_start,
+            d.metrics.datetime.session_daemon_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` AS d
+    )
+"""
+client_id_column = "client_id"
+
+[data_sources.session_duration_table]
+from_expression = """
+    (
+        SELECT 
+            submission_date,
+            app,
+            client_id,
+            session_id,
+            TIMESTAMP_DIFF(MAX(session_end), MIN(session_start), MINUTE) AS session_duration,
+            COUNT(session_start) AS cnt_session_starts,
+            COUNT(session_end) as cnt_session_ends
+
+        FROM (
+            SELECT
+                DATE(v.submission_timestamp) AS submission_date,
+                CONCAT(client_info.os, " - vpn") as app,
+                CASE v.normalized_app_id
+                    WHEN "mozillavpn" then v.client_info.client_id
+                    ELSE v.metrics.uuid.session_installation_id
+                END AS client_id,
+                v.metrics.uuid.session_session_id AS session_id,
+                v.metrics.datetime.session_session_start as session_start,
+                v.metrics.datetime.session_session_end as session_end,
+            FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` v
+
+            UNION ALL
+            SELECT 
+                DATE(d.submission_timestamp) AS submission_date,
+                CONCAT(client_info.os, " - daemon") AS app,
+                d.metrics.uuid.session_installation_id AS client_id,
+                d.metrics.uuid.session_daemon_session_id as session_id,
+                d.metrics.datetime.session_daemon_session_start as session_start,
+                d.metrics.datetime.session_daemon_session_end as session_end,
+            FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` d
+        )
+
+        GROUP BY 
+            submission_date,
+            app,
+            client_id,
+            session_id
+    )
+"""
+client_id_column = "client_id"
+
+[dimensions]
+[dimensions.app]
+data_source = "base_table"
+select_expression = "app"
+
+[metrics]
+[metrics.session_count]
+data_source = "base_table"
+select_expression = "COUNT(DISTINCT session_id)"
+type = "scalar"
+statistics.sum = {}
+
+[metrics.avg_session_duration]
+data_source = "session_duration_table"
+select_expression = "AVG(session_duration)"
+type = "scalar"
+statistics.mean = {}
+statistics.percentile = {}
+
+[metrics.active_subscribers]
+data_source = "base_table"
+select_expression = "COUNT(DISTINCT client_id)"
+type = "scalar"
+statistics.sum = {}
+
+[metrics.avg_sum_session_duration]
+data_source = "session_duration_table"
+select_expression = "SUM(session_duration)"
+type = "scalar"
+statistics.mean = {}
+statistics.percentile = {}
+
+[metrics.cnt_session_starts]
+data_source = "session_duration_table"
+select_expression = "COUNTIF(cnt_session_starts > 0)"
+type = "scalar"
+statistics.sum = {}

--- a/opmon/templates/metric_query.sql
+++ b/opmon/templates/metric_query.sql
@@ -32,9 +32,9 @@ merged_metrics_{{ data_source }} AS (
             GROUP BY
                 population_submission_date,
                 population_client_id,
-                population_build_id,
+                population_build_id
                 {% if config.population.group_by_dimension -%}
-                population_{{ config.population.group_by_dimension.name }}
+                ,population_{{ config.population.group_by_dimension.name }}
                 {% endif -%}
 
         ) AS p
@@ -61,9 +61,9 @@ merged_metrics_{{ data_source }} AS (
     GROUP BY
         submission_date,
         build_id,
-        client_id,
+        client_id
         {% if config.population.group_by_dimension -%}
-        {{ config.population.group_by_dimension.name }}
+        ,{{ config.population.group_by_dimension.name }}
         {% endif %}
 ),
 {% endfor %}

--- a/opmon/templates/metric_query.sql
+++ b/opmon/templates/metric_query.sql
@@ -17,7 +17,7 @@ merged_metrics_{{ data_source }} AS (
         {{ metric.select_expression }} AS {{ metric.name }},
         {% endfor -%}
     FROM
-        {{ metrics[0].data_source.from_expr_for(app_id) }} AS m
+        {{ metrics[0].data_source.from_expr_for(app_id) }}
     RIGHT JOIN
         (
             SELECT
@@ -25,7 +25,7 @@ merged_metrics_{{ data_source }} AS (
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
                 {% if config.population.group_by_dimension -%}
-                {{ config.population.group_by_dimension.select_expression }} AS {{ config.population.group_by_dimension.name }},
+                {{ config.population.group_by_dimension.select_expression }} AS population_{{ config.population.group_by_dimension.name }},
                 {% endif -%}
             FROM
                 population
@@ -34,22 +34,22 @@ merged_metrics_{{ data_source }} AS (
                 population_client_id,
                 population_build_id,
                 {% if config.population.group_by_dimension -%}
-                {{ config.population.group_by_dimension.name }},
+                population_{{ config.population.group_by_dimension.name }}
                 {% endif -%}
 
         ) AS p
     ON
-        m.{{ metrics[0].data_source.submission_date_column }} = p.population_submission_date
+        {{ metrics[0].data_source.submission_date_column }} = p.population_submission_date
         {% if metrics[0].data_source.client_id_column != "NULL" %}
-        AND m.{{ metrics[0].data_source.client_id_column }} = p.population_client_id
+        AND {{ metrics[0].data_source.client_id_column }} = p.population_client_id
         {% endif %}
         {% if config.xaxis.value == "submission_date" %}
         AND p.population_build_id IS NULL
         {% else %}
-        AND m.{{ metrics[0].data_source.build_id_column }} = p.population_build_id
+        AND {{ metrics[0].data_source.build_id_column }} = p.population_build_id
         {% endif %}
         {% if config.population.group_by_dimension -%}
-        AND m.{{ config.population.group_by_dimension.name }} = p.{{ config.population.group_by_dimension.name }}
+        AND {{ config.population.group_by_dimension.name }} = p.population_{{ config.population.group_by_dimension.name }}
         {% endif %}
     WHERE
         {% if config.xaxis.value == "submission_date" %}
@@ -63,7 +63,7 @@ merged_metrics_{{ data_source }} AS (
         build_id,
         client_id,
         {% if config.population.group_by_dimension -%}
-        {{ config.population.group_by_dimension.name }},
+        {{ config.population.group_by_dimension.name }}
         {% endif %}
 ),
 {% endfor %}

--- a/opmon/templates/metric_query.sql
+++ b/opmon/templates/metric_query.sql
@@ -10,34 +10,46 @@ merged_metrics_{{ data_source }} AS (
         DATE({{ metrics[0].data_source.submission_date_column }}) AS submission_date,
         CAST({{ metrics[0].data_source.client_id_column }} AS STRING) AS client_id,
         p.population_build_id AS build_id,
+        {% if config.population.group_by_dimension -%}
+        {{ config.population.group_by_dimension.select_expression }} AS {{ config.population.group_by_dimension.name }},
+        {% endif -%}
         {% for metric in metrics -%}
         {{ metric.select_expression }} AS {{ metric.name }},
         {% endfor -%}
     FROM
-        {{ metrics[0].data_source.from_expr_for(app_id) }}
+        {{ metrics[0].data_source.from_expr_for(app_id) }} AS m
     RIGHT JOIN
         (
             SELECT
                 client_id AS population_client_id,
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
+                {% if config.population.group_by_dimension -%}
+                {{ config.population.group_by_dimension.select_expression }} AS {{ config.population.group_by_dimension.name }},
+                {% endif -%}
             FROM
                 population
             GROUP BY
-                population_client_id,
                 population_submission_date,
-                population_build_id
+                population_client_id,
+                population_build_id,
+                {% if config.population.group_by_dimension -%}
+                {{ config.population.group_by_dimension.name }},
+                {% endif -%}
 
         ) AS p
     ON
-        {{ metrics[0].data_source.submission_date_column }} = p.population_submission_date
+        m.{{ metrics[0].data_source.submission_date_column }} = p.population_submission_date
         {% if metrics[0].data_source.client_id_column != "NULL" %}
-        AND {{ metrics[0].data_source.client_id_column }} = p.population_client_id
+        AND m.{{ metrics[0].data_source.client_id_column }} = p.population_client_id
         {% endif %}
         {% if config.xaxis.value == "submission_date" %}
         AND p.population_build_id IS NULL
         {% else %}
-        AND {{ metrics[0].data_source.build_id_column }} = p.population_build_id
+        AND m.{{ metrics[0].data_source.build_id_column }} = p.population_build_id
+        {% endif %}
+        {% if config.population.group_by_dimension -%}
+        AND m.{{ config.population.group_by_dimension.name }} = p.{{ config.population.group_by_dimension.name }}
         {% endif %}
     WHERE
         {% if config.xaxis.value == "submission_date" %}
@@ -49,7 +61,10 @@ merged_metrics_{{ data_source }} AS (
     GROUP BY
         submission_date,
         build_id,
-        client_id
+        client_id,
+        {% if config.population.group_by_dimension -%}
+        {{ config.population.group_by_dimension.name }},
+        {% endif %}
 ),
 {% endfor %}
 
@@ -77,6 +92,9 @@ joined_metrics AS (
     merged_metrics_{{ data_source }}.client_id = population.client_id AND
     {% endif %}
     (population.build_id IS NULL OR merged_metrics_{{ data_source }}.build_id = population.build_id)
+    {% if config.population.group_by_dimension -%}
+    AND merged_metrics_{{ data_source }}.{{ config.population.group_by_dimension.name }} = population.{{ config.population.group_by_dimension.name }}
+    {% endif %}
   {% endfor %}
 ),
 

--- a/output.sql
+++ b/output.sql
@@ -102,7 +102,6 @@ merged_metrics_session_duration_table AS (
         DATE(submission_date) AS submission_date,
         CAST(client_id AS STRING) AS client_id,
         p.population_build_id AS build_id,
-        app AS app,
         AVG(session_duration) AS avg_session_duration,
         SUM(session_duration) AS avg_sum_session_duration,
         FROM
@@ -153,14 +152,12 @@ merged_metrics_session_duration_table AS (
                 client_id AS population_client_id,
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
-                app AS population_app,
                 FROM
                 population
             GROUP BY
                 population_submission_date,
                 population_client_id,
-                population_build_id,
-                population_app
+                population_build_id
                 ) AS p
     ON
         submission_date = p.population_submission_date
@@ -170,7 +167,6 @@ merged_metrics_session_duration_table AS (
         
         AND p.population_build_id IS NULL
         
-        AND app = p.population_app
         
     WHERE
         
@@ -179,8 +175,7 @@ merged_metrics_session_duration_table AS (
     GROUP BY
         submission_date,
         build_id,
-        client_id,
-        app
+        client_id
         
 ),
 merged_metrics_base_table AS (
@@ -188,7 +183,6 @@ merged_metrics_base_table AS (
         DATE(submission_date) AS submission_date,
         CAST(client_id AS STRING) AS client_id,
         p.population_build_id AS build_id,
-        app AS app,
         COUNT(DISTINCT client_id) AS active_subscribers,
         COUNT(DISTINCT session_id) AS session_count,
         FROM
@@ -224,14 +218,12 @@ merged_metrics_base_table AS (
                 client_id AS population_client_id,
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
-                app AS population_app,
                 FROM
                 population
             GROUP BY
                 population_submission_date,
                 population_client_id,
-                population_build_id,
-                population_app
+                population_build_id
                 ) AS p
     ON
         submission_date = p.population_submission_date
@@ -241,7 +233,6 @@ merged_metrics_base_table AS (
         
         AND p.population_build_id IS NULL
         
-        AND app = p.population_app
         
     WHERE
         
@@ -250,8 +241,7 @@ merged_metrics_base_table AS (
     GROUP BY
         submission_date,
         build_id,
-        client_id,
-        app
+        client_id
         
 ),
 
@@ -277,7 +267,6 @@ joined_metrics AS (
     merged_metrics_session_duration_table.client_id = population.client_id AND
     
     (population.build_id IS NULL OR merged_metrics_session_duration_table.build_id = population.build_id)
-    AND merged_metrics_session_duration_table.app = population.app
     
   LEFT JOIN merged_metrics_base_table
   ON
@@ -286,7 +275,6 @@ joined_metrics AS (
     merged_metrics_base_table.client_id = population.client_id AND
     
     (population.build_id IS NULL OR merged_metrics_base_table.build_id = population.build_id)
-    AND merged_metrics_base_table.app = population.app
     
   
 ),

--- a/output.sql
+++ b/output.sql
@@ -102,6 +102,7 @@ merged_metrics_session_duration_table AS (
         DATE(submission_date) AS submission_date,
         CAST(client_id AS STRING) AS client_id,
         p.population_build_id AS build_id,
+        app AS app,
         AVG(session_duration) AS avg_session_duration,
         SUM(session_duration) AS avg_sum_session_duration,
         FROM
@@ -152,12 +153,14 @@ merged_metrics_session_duration_table AS (
                 client_id AS population_client_id,
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
+                app AS population_app,
                 FROM
                 population
             GROUP BY
                 population_submission_date,
                 population_client_id,
                 population_build_id
+                ,population_app
                 ) AS p
     ON
         submission_date = p.population_submission_date
@@ -167,6 +170,7 @@ merged_metrics_session_duration_table AS (
         
         AND p.population_build_id IS NULL
         
+        AND app = p.population_app
         
     WHERE
         
@@ -176,6 +180,7 @@ merged_metrics_session_duration_table AS (
         submission_date,
         build_id,
         client_id
+        ,app
         
 ),
 merged_metrics_base_table AS (
@@ -183,6 +188,7 @@ merged_metrics_base_table AS (
         DATE(submission_date) AS submission_date,
         CAST(client_id AS STRING) AS client_id,
         p.population_build_id AS build_id,
+        app AS app,
         COUNT(DISTINCT client_id) AS active_subscribers,
         COUNT(DISTINCT session_id) AS session_count,
         FROM
@@ -218,12 +224,14 @@ merged_metrics_base_table AS (
                 client_id AS population_client_id,
                 submission_date AS population_submission_date,
                 build_id AS population_build_id,
+                app AS population_app,
                 FROM
                 population
             GROUP BY
                 population_submission_date,
                 population_client_id,
                 population_build_id
+                ,population_app
                 ) AS p
     ON
         submission_date = p.population_submission_date
@@ -233,6 +241,7 @@ merged_metrics_base_table AS (
         
         AND p.population_build_id IS NULL
         
+        AND app = p.population_app
         
     WHERE
         
@@ -242,6 +251,7 @@ merged_metrics_base_table AS (
         submission_date,
         build_id,
         client_id
+        ,app
         
 ),
 
@@ -267,6 +277,7 @@ joined_metrics AS (
     merged_metrics_session_duration_table.client_id = population.client_id AND
     
     (population.build_id IS NULL OR merged_metrics_session_duration_table.build_id = population.build_id)
+    AND merged_metrics_session_duration_table.app = population.app
     
   LEFT JOIN merged_metrics_base_table
   ON
@@ -275,6 +286,7 @@ joined_metrics AS (
     merged_metrics_base_table.client_id = population.client_id AND
     
     (population.build_id IS NULL OR merged_metrics_base_table.build_id = population.build_id)
+    AND merged_metrics_base_table.app = population.app
     
   
 ),

--- a/output.sql
+++ b/output.sql
@@ -1,0 +1,306 @@
+-- Generated via opmon
+
+
+WITH population AS (
+    SELECT
+        DATE(submission_date) AS submission_date,
+        CAST(client_id AS STRING) AS client_id,
+        
+        NULL AS build_id,
+        
+        CAST(app AS STRING) AS app,
+        -- If a pref is defined, treat it as a rollout with an enabled and disabled branch.
+        -- If branches are provided, use those instead.
+        -- If neither a pref or branches are available, use the slug and treat it as a rollout
+        -- where those with the slug have the feature enabled and those without do not.
+        
+          "active" AS branch,
+        
+    FROM
+        (
+          -- filter out clients that send more than 10000 pings
+          SELECT * 
+          FROM     (
+        SELECT
+            "vpnsession" as source_table,
+            DATE(v.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - vpn") as app,
+            CASE v.normalized_app_id
+                WHEN "mozillavpn" THEN v.client_info.client_id
+                ELSE v.metrics.uuid.session_installation_id
+            END AS client_id,
+            v.metrics.uuid.session_session_id AS session_id,
+            v.metrics.datetime.session_session_start AS session_start,
+            v.metrics.datetime.session_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` AS v
+
+        UNION ALL
+        SELECT 
+            "daemonsession" AS source_table,
+            DATE(d.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - daemon") AS app,
+            d.metrics.uuid.session_installation_id AS client_id,
+            d.metrics.uuid.session_daemon_session_id AS session_id,
+            d.metrics.datetime.session_daemon_session_start AS session_start,
+            d.metrics.datetime.session_daemon_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` AS d
+    )
+ 
+          WHERE client_id NOT IN (
+            SELECT client_id AS client_id
+            FROM     (
+        SELECT
+            "vpnsession" as source_table,
+            DATE(v.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - vpn") as app,
+            CASE v.normalized_app_id
+                WHEN "mozillavpn" THEN v.client_info.client_id
+                ELSE v.metrics.uuid.session_installation_id
+            END AS client_id,
+            v.metrics.uuid.session_session_id AS session_id,
+            v.metrics.datetime.session_session_start AS session_start,
+            v.metrics.datetime.session_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` AS v
+
+        UNION ALL
+        SELECT 
+            "daemonsession" AS source_table,
+            DATE(d.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - daemon") AS app,
+            d.metrics.uuid.session_installation_id AS client_id,
+            d.metrics.uuid.session_daemon_session_id AS session_id,
+            d.metrics.datetime.session_daemon_session_start AS session_start,
+            d.metrics.datetime.session_daemon_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` AS d
+    )
+ 
+            WHERE submission_date = DATE('2024-02-09')
+            -- client_id is set to NULL when we want to compute metrics across all clients (default is per client)
+            -- keep 'NULL' clients
+            AND client_id IS NOT NULL
+            GROUP BY client_id
+            HAVING COUNT(*) > 10000
+          )
+        )
+    WHERE
+        
+        DATE(submission_date) = DATE('2024-02-09')
+        
+        
+    GROUP BY
+        submission_date,
+        client_id,
+        build_id,
+        app,
+        branch
+),
+
+-- for each data source that is used
+-- select the metric values
+merged_metrics_session_duration_table AS (
+    SELECT
+        DATE(submission_date) AS submission_date,
+        CAST(client_id AS STRING) AS client_id,
+        p.population_build_id AS build_id,
+        app AS app,
+        AVG(session_duration) AS avg_session_duration,
+        SUM(session_duration) AS avg_sum_session_duration,
+        FROM
+            (
+        SELECT 
+            submission_date,
+            app,
+            client_id,
+            session_id,
+            TIMESTAMP_DIFF(MAX(session_end), MIN(session_start), MINUTE) AS session_duration,
+            COUNT(session_start) AS cnt_session_starts,
+            COUNT(session_end) as cnt_session_ends
+
+        FROM (
+            SELECT
+                DATE(v.submission_timestamp) AS submission_date,
+                CONCAT(client_info.os, " - vpn") as app,
+                CASE v.normalized_app_id
+                    WHEN "mozillavpn" then v.client_info.client_id
+                    ELSE v.metrics.uuid.session_installation_id
+                END AS client_id,
+                v.metrics.uuid.session_session_id AS session_id,
+                v.metrics.datetime.session_session_start as session_start,
+                v.metrics.datetime.session_session_end as session_end,
+            FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` v
+
+            UNION ALL
+            SELECT 
+                DATE(d.submission_timestamp) AS submission_date,
+                CONCAT(client_info.os, " - daemon") AS app,
+                d.metrics.uuid.session_installation_id AS client_id,
+                d.metrics.uuid.session_daemon_session_id as session_id,
+                d.metrics.datetime.session_daemon_session_start as session_start,
+                d.metrics.datetime.session_daemon_session_end as session_end,
+            FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` d
+        )
+
+        GROUP BY 
+            submission_date,
+            app,
+            client_id,
+            session_id
+    )
+
+    RIGHT JOIN
+        (
+            SELECT
+                client_id AS population_client_id,
+                submission_date AS population_submission_date,
+                build_id AS population_build_id,
+                app AS population_app,
+                FROM
+                population
+            GROUP BY
+                population_submission_date,
+                population_client_id,
+                population_build_id,
+                population_app
+                ) AS p
+    ON
+        submission_date = p.population_submission_date
+        
+        AND client_id = p.population_client_id
+        
+        
+        AND p.population_build_id IS NULL
+        
+        AND app = p.population_app
+        
+    WHERE
+        
+        DATE(submission_date) = DATE('2024-02-09')
+        
+    GROUP BY
+        submission_date,
+        build_id,
+        client_id,
+        app
+        
+),
+merged_metrics_base_table AS (
+    SELECT
+        DATE(submission_date) AS submission_date,
+        CAST(client_id AS STRING) AS client_id,
+        p.population_build_id AS build_id,
+        app AS app,
+        COUNT(DISTINCT client_id) AS active_subscribers,
+        COUNT(DISTINCT session_id) AS session_count,
+        FROM
+            (
+        SELECT
+            "vpnsession" as source_table,
+            DATE(v.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - vpn") as app,
+            CASE v.normalized_app_id
+                WHEN "mozillavpn" THEN v.client_info.client_id
+                ELSE v.metrics.uuid.session_installation_id
+            END AS client_id,
+            v.metrics.uuid.session_session_id AS session_id,
+            v.metrics.datetime.session_session_start AS session_start,
+            v.metrics.datetime.session_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.vpnsession` AS v
+
+        UNION ALL
+        SELECT 
+            "daemonsession" AS source_table,
+            DATE(d.submission_timestamp) AS submission_date,
+            CONCAT(client_info.os, " - daemon") AS app,
+            d.metrics.uuid.session_installation_id AS client_id,
+            d.metrics.uuid.session_daemon_session_id AS session_id,
+            d.metrics.datetime.session_daemon_session_start AS session_start,
+            d.metrics.datetime.session_daemon_session_end AS session_end,
+        FROM `moz-fx-data-shared-prod.mozilla_vpn.daemonsession` AS d
+    )
+
+    RIGHT JOIN
+        (
+            SELECT
+                client_id AS population_client_id,
+                submission_date AS population_submission_date,
+                build_id AS population_build_id,
+                app AS population_app,
+                FROM
+                population
+            GROUP BY
+                population_submission_date,
+                population_client_id,
+                population_build_id,
+                population_app
+                ) AS p
+    ON
+        submission_date = p.population_submission_date
+        
+        AND client_id = p.population_client_id
+        
+        
+        AND p.population_build_id IS NULL
+        
+        AND app = p.population_app
+        
+    WHERE
+        
+        DATE(submission_date) = DATE('2024-02-09')
+        
+    GROUP BY
+        submission_date,
+        build_id,
+        client_id,
+        app
+        
+),
+
+
+-- combine the metrics from all the data sources
+joined_metrics AS (
+  SELECT
+    population.submission_date AS submission_date,
+    population.client_id AS client_id,
+    population.build_id,
+    population.app AS app,
+    
+    population.branch AS branch,
+    avg_session_duration,
+        avg_sum_session_duration,
+        active_subscribers,
+        session_count,
+        FROM population
+  LEFT JOIN merged_metrics_session_duration_table
+  ON
+    merged_metrics_session_duration_table.submission_date = population.submission_date AND
+    
+    merged_metrics_session_duration_table.client_id = population.client_id AND
+    
+    (population.build_id IS NULL OR merged_metrics_session_duration_table.build_id = population.build_id)
+    AND merged_metrics_session_duration_table.app = population.app
+    
+  LEFT JOIN merged_metrics_base_table
+  ON
+    merged_metrics_base_table.submission_date = population.submission_date AND
+    
+    merged_metrics_base_table.client_id = population.client_id AND
+    
+    (population.build_id IS NULL OR merged_metrics_base_table.build_id = population.build_id)
+    AND merged_metrics_base_table.app = population.app
+    
+  
+),
+
+-- normalize histograms and apply filters
+normalized_metrics AS (
+    SELECT
+        *
+    FROM joined_metrics
+    
+)
+SELECT
+    * REPLACE(DATE('2024-02-09') AS submission_date)
+FROM
+    normalized_metrics
+
+

--- a/test_thing.py
+++ b/test_thing.py
@@ -1,0 +1,19 @@
+from metric_config_parser.monitoring import MonitoringConfiguration, MonitoringSpec
+import toml
+
+from opmon.config import ConfigLoader
+from opmon.monitoring import Monitoring
+
+
+spec = MonitoringSpec.from_dict(toml.load("mozilla_vpn.toml")).resolve(experiment=None, configs=ConfigLoader.configs)
+config = ("desktop-dau", spec)
+monitoring = Monitoring(
+        project="moz-fx-data-shared-prod",
+        dataset="some_dataset",
+        derived_dataset="some_derived_dataset",
+        slug=config[0],
+        config=config[1],
+        before_execute_callback=None,
+    )
+sql = monitoring._get_metrics_sql(first_run=True, submission_date="2024-02-09", table_name="my-table")
+print(sql)


### PR DESCRIPTION
if there is no group_by_dimension there can't be a trailing comma in the group by.
moving the comma inside the if statement fixes that