### PR TITLE
chore: disable monitor cirrus app from analysis

### DIFF
--- a/opmon/tests/test_config.py
+++ b/opmon/tests/test_config.py
@@ -16,28 +16,44 @@ class TestConfigLoader:
             ["https://github.com/mozilla/metric-hub/tree/main/opmon"]
         )
         assert configs_collection.configs is not None
-        assert len(configs_collection.configs.configs) == len(ConfigLoader.configs.configs)
+        assert len(configs_collection.configs.configs) == len(
+            ConfigLoader.configs.configs
+        )
 
     def test_spec_for_experiment(self):
         experiment = next(
-            c.slug for c in ConfigLoader.configs.configs if isinstance(c.spec, MonitoringSpec)
+            c.slug
+            for c in ConfigLoader.configs.configs
+            if isinstance(c.spec, MonitoringSpec)
         )
         assert ConfigLoader.configs.spec_for_project(experiment) is not None
 
     def test_spec_for_nonexisting_experiment(self):
-        assert ConfigLoader.configs.spec_for_project("non_exisiting") is None
+        assert ConfigLoader.configs.spec_for_project("non_existing") is None
 
     def test_get_nonexisting_outcome(self):
         assert ConfigLoader.configs.spec_for_outcome("non_existing", "foo") is None
 
     def test_get_data_source(self):
-        metric = list(ConfigLoader.configs.definitions[0].spec.metrics.definitions.values())[0]
-        platform = ConfigLoader.configs.definitions[0].platform
+        definition = [
+            d for d in ConfigLoader.configs.definitions if d.platform != "functions"
+        ][0]
+        metric = [
+            m
+            for m in definition.spec.metrics.definitions.values()
+            if m.data_source is not None
+        ][0]
+        platform = definition.platform
 
         assert (
-            ConfigLoader.configs.get_data_source_definition(metric.data_source.name, platform)
+            ConfigLoader.configs.get_data_source_definition(
+                metric.data_source.name, platform
+            )
             is not None
         )
 
     def test_get_nonexisting_data_source(self):
-        assert ConfigLoader.configs.get_data_source_definition("non_existing", "foo") is None
+        assert (
+            ConfigLoader.configs.get_data_source_definition("non_existing", "foo")
+            is None
+        )

--- a/opmon/tests/test_config.py
+++ b/opmon/tests/test_config.py
@@ -16,15 +16,11 @@ class TestConfigLoader:
             ["https://github.com/mozilla/metric-hub/tree/main/opmon"]
         )
         assert configs_collection.configs is not None
-        assert len(configs_collection.configs.configs) == len(
-            ConfigLoader.configs.configs
-        )
+        assert len(configs_collection.configs.configs) == len(ConfigLoader.configs.configs)
 
     def test_spec_for_experiment(self):
         experiment = next(
-            c.slug
-            for c in ConfigLoader.configs.configs
-            if isinstance(c.spec, MonitoringSpec)
+            c.slug for c in ConfigLoader.configs.configs if isinstance(c.spec, MonitoringSpec)
         )
         assert ConfigLoader.configs.spec_for_project(experiment) is not None
 
@@ -35,25 +31,16 @@ class TestConfigLoader:
         assert ConfigLoader.configs.spec_for_outcome("non_existing", "foo") is None
 
     def test_get_data_source(self):
-        definition = [
-            d for d in ConfigLoader.configs.definitions if d.platform != "functions"
-        ][0]
+        definition = [d for d in ConfigLoader.configs.definitions if d.platform != "functions"][0]
         metric = [
-            m
-            for m in definition.spec.metrics.definitions.values()
-            if m.data_source is not None
+            m for m in definition.spec.metrics.definitions.values() if m.data_source is not None
         ][0]
         platform = definition.platform
 
         assert (
-            ConfigLoader.configs.get_data_source_definition(
-                metric.data_source.name, platform
-            )
+            ConfigLoader.configs.get_data_source_definition(metric.data_source.name, platform)
             is not None
         )
 
     def test_get_nonexisting_data_source(self):
-        assert (
-            ConfigLoader.configs.get_data_source_definition("non_existing", "foo")
-            is None
-        )
+        assert ConfigLoader.configs.get_data_source_definition("non_existing", "foo") is None

--- a/platform_config.toml
+++ b/platform_config.toml
@@ -33,9 +33,10 @@ app_id = { release = "org.mozilla.klar" }
 is_glean_app = true
 app_id = { release = "org.mozilla.focus", beta = "org.mozilla.focus.beta", nightly = "org.mozilla.focus.nightly" }
 
-[platform.monitor_cirrus]
-is_glean_app = true
-app_id = { release = "monitor.cirrus" }
+# Disabled until web analysis is better understood.
+# [platform.monitor_cirrus]
+# is_glean_app = true
+# app_id = { release = "monitor.cirrus" }
 
 [platform.mozilla_vpn]
 is_glean_app = true


### PR DESCRIPTION
We're not using automated analysis for rollouts at the moment, so disabling this for now.

Related to mozilla/jetstream#2441 