### PR TITLE
chore: use less specific action versions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,13 +14,13 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.10.8
     - name: restore_cache
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v3
       with:
         key: python-packages-v1-{{ .Branch }}-{{ checksum "requirements.in" }}-{{ checksum "requirements.txt" }}
         path: venv/
@@ -50,7 +50,7 @@ jobs:
       run: docker build . -t opmon
     - name: Push the Docker image to GAR
       if: github.ref == 'refs/heads/main'
-      uses: mozilla-it/deploy-actions/docker-push@v3.11.1
+      uses: mozilla-it/deploy-actions/docker-push@v3
       with:
         project_id: moz-fx-data-experiments
         local_image: opmon


### PR DESCRIPTION
The latest build failed because it didn't like the version numbers we used, so changing to more generic ones that should theoretically allow the package to stay up to date (at least by the major version number). This assumes the action's repo properly updates these major version tags, but as of now, all three of these packages are either up-to-date (actions/checkout, actions/cache) or at least up to date with our existing pinned version (mozilla-it/deploy-actions/docker-push `v3` points to same commit as `v3.11.1`).