### PR TITLE
Check if experiment exists

### DIFF
--- a/opmon/cli.py
+++ b/opmon/cli.py
@@ -188,6 +188,14 @@ def run(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
+        if experiment is None:
+            logger.exception(
+                str(f"Invalid experiment {external_config.slug}"),
+                exc_info=None,
+                extra={"experiment": external_config.slug},
+            )
+            continue
+
         platform = external_config.spec.project.platform or experiment.app_name or DEFAULT_PLATFORM
         platform_definitions = ConfigLoader.configs.get_platform_definitions(platform)
 
@@ -394,6 +402,14 @@ def backfill(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
+        if experiment is None:
+            logger.exception(
+                str(f"Invalid experiment {external_config.slug}"),
+                exc_info=None,
+                extra={"experiment": external_config.slug},
+            )
+            continue
+
         platform = external_config.spec.project.platform or experiment.app_name or DEFAULT_PLATFORM
         platform_definitions = ConfigLoader.configs.get_platform_definitions(platform)
 


### PR DESCRIPTION
Failures in https://workflow.telemetry.mozilla.org/dags/operational_monitoring/grid?search=operational_monitoring&dag_run_id=scheduled__2025-03-27T04%3A00%3A00%2B00%3A00&task_id=opmon_run&tab=logs

This might be related to the change in https://github.com/mozilla/opmon/pull/195 which could result in some experiments not being pulled in anymore. But it is probably good to have this check in any case