### PR TITLE
Fix for running experiments that have no entry in experimenter as long as they have a config

### DIFF
--- a/opmon/cli.py
+++ b/opmon/cli.py
@@ -188,22 +188,18 @@ def run(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
-        if experiment is None:
-            logger.exception(
-                str(f"Invalid experiment {external_config.slug}"),
-                exc_info=None,
-                extra={"experiment": external_config.slug},
-            )
-            continue
-
-        platform = external_config.spec.project.platform or experiment.app_name or DEFAULT_PLATFORM
+        platform = (
+            external_config.spec.project.platform
+            or (experiment is not None and experiment.app_name)
+            or DEFAULT_PLATFORM
+        )
         platform_definitions = ConfigLoader.configs.get_platform_definitions(platform)
 
         if platform_definitions is None:
             logger.exception(
                 str(f"Invalid platform {platform}"),
                 exc_info=None,
-                extra={"experiment": experiment.normandy_slug},
+                extra={"experiment": external_config.slug},
             )
             continue
 
@@ -402,22 +398,18 @@ def backfill(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
-        if experiment is None:
-            logger.exception(
-                str(f"Invalid experiment {external_config.slug}"),
-                exc_info=None,
-                extra={"experiment": external_config.slug},
-            )
-            continue
-
-        platform = external_config.spec.project.platform or experiment.app_name or DEFAULT_PLATFORM
+        platform = (
+            external_config.spec.project.platform
+            or (experiment is not None and experiment.app_name)
+            or DEFAULT_PLATFORM
+        )
         platform_definitions = ConfigLoader.configs.get_platform_definitions(platform)
 
         if platform_definitions is None:
             logger.exception(
                 str(f"Invalid platform {platform}"),
                 exc_info=None,
-                extra={"experiment": experiment.normandy_slug},
+                extra={"experiment": external_config.slug},
             )
             continue
 


### PR DESCRIPTION
In many cases there might not be a experiment in experimenter, but instead there is just a custom config. Opmon should still run for those.

This is a regression from https://github.com/mozilla/opmon/pull/196
