### PR TITLE
Fix opmon experiments not in experimenter

### DIFF
--- a/opmon/cli.py
+++ b/opmon/cli.py
@@ -188,6 +188,14 @@ def run(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
+        if external_config.spec.project.platform is None and experiment is None:
+            logger.info(
+                str(f"No platform defined for {external_config.slug}"),
+                exc_info=None,
+                extra={"experiment": external_config.slug},
+            )
+            continue
+
         platform = (
             external_config.spec.project.platform
             or (experiment is not None and experiment.app_name)
@@ -398,6 +406,14 @@ def backfill(
             continue
 
         experiment = experiments.with_slug(external_config.slug)
+        if external_config.spec.project.platform is None and experiment is None:
+            logger.info(
+                str(f"No platform defined for {external_config.slug}"),
+                exc_info=None,
+                extra={"experiment": external_config.slug},
+            )
+            continue
+
         platform = (
             external_config.spec.project.platform
             or (experiment is not None and experiment.app_name)

--- a/opmon/monitoring.py
+++ b/opmon/monitoring.py
@@ -1,5 +1,6 @@
 """Generate and run the Operational Monitoring Queries."""
 
+import copy
 import itertools
 import os
 import re
@@ -124,7 +125,7 @@ class Monitoring:
 
         table_name = f"{self.normalized_slug}_v{SCHEMA_VERSIONS['metric']}"
 
-        join_keys = METRICS_JOIN_KEYS
+        join_keys = copy.deepcopy(METRICS_JOIN_KEYS)
         for dimension in self.config.dimensions:
             join_keys.append(dimension.name)
 

--- a/opmon/tests/test_experimenter.py
+++ b/opmon/tests/test_experimenter.py
@@ -6,12 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 import pytz
 
-from opmon.experimenter import (
-    Branch,
-    Experiment,
-    ExperimentCollection,
-    ExperimentV8,
-)
+from opmon.experimenter import Branch, Experiment, ExperimentCollection, ExperimentV8
 
 EXPERIMENTER_FIXTURE_V8 = r"""
 [


### PR DESCRIPTION
`join_keys` are being generated from dimensions for multipart metric queries. There are a set of fixed dimensions which are joined onto a set of custom dimensions (as defined in the configs). This PR fixes a bug where we ended up joining all dimensions over time.